### PR TITLE
Fix tox factor name to actually run tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: python
 
 services:

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'dev': [
             "coverage==4.0.3",
             "flake8==3.3.0",
+            "isort<5",
             "pylint==1.8.2",
             "pytest==2.8.3",
             "objgraph==3.1.0"

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,5 @@ commands =
     static: make flake8
     static: make pylint
 
-    lib: pip install --editable .[dev]
-    lib: make pytest
+    test: pip install --editable .[dev]
+    test: make pytest


### PR DESCRIPTION
While attempting to start work on #24, I've noticed that all tox envs are green but... tox doesn't actually run the tests. This PR fixes factor name in tox.ini so that the proper commands are executed. 